### PR TITLE
fix: Docker 컨테이너에서 호스트 Ollama 연결 불가 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ __marimo__/
 
 # etc
 *.jsonl
+.idea/
+*.iml
+*.xml

--- a/config.py
+++ b/config.py
@@ -20,3 +20,7 @@ ROUTING_RATIO = 0.5
 
 # === 로그 파일 경로 ===
 LOG_FILE_PATH = "traffic_log.jsonl"
+
+# === Ollama 접속 주소 ===
+# 환경변수가 있으면 그걸 쓰고, 없으면 localhost(기본값)를 씁니다.
+OLLAMA_API_BASE = os.getenv("OLLAMA_API_BASE", "http://localhost:11434")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    environment:
+      - OLLAMA_API_BASE=http://host.docker.internal:11434
     depends_on:
       - redis # Redis가 켜져야 나도 켜짐
     networks:

--- a/main.py
+++ b/main.py
@@ -56,7 +56,8 @@ async def chat_endpoint(request: ChatRequest, background_tasks: BackgroundTasks)
     try:
         response = completion(
             model=selected_model,
-            messages=[{"role": "user", "content": request.message}]
+            messages=[{"role": "user", "content": request.message}],
+            api_base=config.OLLAMA_API_BASE
         )
 
         reply_text = response.choices[0].message.content


### PR DESCRIPTION
- config.py: OLLAMA_API_BASE 환경변수 처리 로직 추가 (기본값: localhost)
- main.py: 하드코딩된 API 주소를 config 기반으로 변경하여 유연성 확보
- docker-compose.yml: host.docker.internal DNS를 사용하여 컨테이너가 호스트의 Ollama(11434)에 접근하도록 환경변수 주입

Resolves #7