### PR TITLE
fix: OpenAI 요청 시 올바르지 않은 api_base가 적용되는 버그 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # 1. 우리의 주인공 (FastAPI 서버)
   prism-app:


### PR DESCRIPTION
- main.py: completion 호출 시 무조건 로컬 api_base를 적용하던 로직 제거
- 모델 타입(Local/Cloud)을 감지하여 Local일 때만 커스텀 엔드포인트 적용
- OpenAI 요청은 기본 엔드포인트(api.openai.com)를 타도록 수정

Resolves #9