### PR TITLE
feat: Streamlit 기반 채팅 웹 인터페이스 구현 및 Docker 연동

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  # 1. 우리의 주인공 (FastAPI 서버)
+  # 1. FastAPI Server
   prism-app:
     build: .
     container_name: prism-gateway
@@ -45,6 +45,19 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin # 초기 비번 설정
     depends_on:
       - prometheus
+    networks:
+      - prism-network
+
+  # 5. FrontEnd Service
+  prism-frontend:
+    build: .
+    container_name: prism-frontend
+    # 이미지가 켜지면 실행할 명령어
+    command: streamlit run frontend/app.py --server.port 8501 --server.address 0.0.0.0
+    ports:
+      - "8501:8501" # 웹 브라우저 접속 포트
+    depends_on:
+      - prism-app # 백엔드가 켜져야 나도 켜짐
     networks:
       - prism-network
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,57 @@
+# frontend/app.py
+import streamlit as st
+import requests
+import time
+
+# 페이지 설정
+st.set_page_config(page_title="PrismOps Chat", page_icon="💎")
+
+st.title("💎 PrismOps AI Chat")
+st.caption("🚀 Powered by Ollama & OpenAI with A/B Routing")
+
+# 세션 상태 초기화 (대화 기록 저장)
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+# 기존 대화 기록 표시
+for message in st.session_state.messages:
+    with st.chat_message(message["role"]):
+        st.markdown(message["content"])
+
+# 사용자 입력 처리
+if prompt := st.chat_input("메시지를 입력하세요..."):
+    # 1. 사용자 메시지 표시
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    # 2. API 호출
+    with st.chat_message("assistant"):
+        message_placeholder = st.empty()
+        message_placeholder.markdown("Thinking...")
+
+        try:
+            # Docker 내부 통신용 URL (prism-app 컨테이너를 가리킴)
+            # 주의: 브라우저가 아니라 '컨테이너'가 요청을 보내므로 localhost가 아님!
+            api_url = "http://prism-app:8000/chat"
+
+            payload = {"message": prompt}
+            response = requests.post(api_url, json=payload)
+
+            if response.status_code == 200:
+                data = response.json()
+                reply = data["reply"]
+                model = data["model"]
+                latency = data["latency"]
+
+                # 답변 표시 (모델 정보와 지연시간도 함께)
+                full_response = f"{reply}\n\n---\n*🏷️ Model: `{model}` | ⏱️ Latency: `{latency}s`*"
+                message_placeholder.markdown(full_response)
+
+                # 대화 기록에 저장
+                st.session_state.messages.append({"role": "assistant", "content": full_response})
+            else:
+                message_placeholder.error(f"Error: {response.status_code}")
+
+        except Exception as e:
+            message_placeholder.error(f"Connection Failed: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ async def chat_endpoint(request: ChatRequest, background_tasks: BackgroundTasks)
 
     print(f"🔀 [Router] {tag} 선택됨 -> {selected_model}")
 
-    # [Fix Issue #6] 모델 타입에 따른 API 주소 분기 처리
+    # 모델 타입에 따른 API 주소 분기 처리
     # 기본값은 None으로 설정 (OpenAI는 주소를 따로 설정할 필요 없음)
     custom_api_base = None
 
@@ -104,5 +104,5 @@ async def chat_endpoint(request: ChatRequest, background_tasks: BackgroundTasks)
         }
         background_tasks.add_task(logger.log_transaction, error_data)
 
-        print(f"❌ [Error] {str(e)}")
+        print(f"[Error] {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ litellm
 python-dotenv
 prometheus-fastapi-instrumentator
 requests
+streamlit


### PR DESCRIPTION
- requirements.txt: Streamlit 라이브러리 추가
- frontend/app.py: Streamlit Chat UI 및 API 연동 로직 구현
- docker-compose.yml: prism-frontend 서비스 추가 (Port 8501)
- 컨테이너 내부 네트워크(prism-app:8000)를 통한 백엔드 통신 구현

Resolves #11